### PR TITLE
修复第4节一个链接错误

### DIFF
--- a/4-project-construction.md
+++ b/4-project-construction.md
@@ -40,7 +40,7 @@
 
 目录`/public`是WebAPP存放静态资源的地方。这些静态资源包含css文件、浏览器运行的js文件、图片文件等。静态资源不需要设置任何路由就能直接通过链接访问。
 
-比如通过\`[http://localhost:3000/stylesheets/style.css\`](http://localhost:3000/stylesheets/style.css`) 可以在浏览器直接读取style.css，这样做的目的是方便浏览器在解析html页面时更方便得获得静态资源。
+比如通过\`[http://localhost:3000/stylesheets/style.css\`](http://localhost:3000/stylesheets/style.css) 可以在浏览器直接读取style.css，这样做的目的是方便浏览器在解析html页面时更方便得获得静态资源。
 
 #### /routes
 


### PR DESCRIPTION
修复第4节一个链接错误。
因为多了一个标点，在页面点击链接会404。